### PR TITLE
Switch to use `GITHUB_OUTPUT`

### DIFF
--- a/.github/actions/get-idris-sha/action.yml
+++ b/.github/actions/get-idris-sha/action.yml
@@ -16,5 +16,5 @@ runs:
     - name: Get SHA
       id: get-sha
       run: |
-        echo "::set-output name=sha::$(curl -s 'https://api.github.com/repos/idris-lang/Idris2/commits' | jq -r '.[0].sha')"
+        echo "name=sha::$(curl -s 'https://api.github.com/repos/idris-lang/Idris2/commits' | jq -r '.[0].sha')" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Update Github actions to use `GITHUB_OUTPUT` instead of `set-output`.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/