### PR TITLE
Fix devcontainer build: move base image to bookworm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
     "name": "Idris2 Dockerfiles",
-    "image": "mcr.microsoft.com/devcontainers/python:2-3.11-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},


### PR DESCRIPTION
Update the base image because Yarn's GPG signing key in the previous repo expired. 