### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/actions/build-base-img/action.yml
+++ b/.github/actions/build-base-img/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
 
     - name: Build Base (versioned)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       if: ${{ inputs.idris-version != 'latest' }}
       with:
         context: .
@@ -68,7 +68,7 @@ runs:
         cache-to: ${{ steps.calculate-cache-to.outputs.cache-to }}
 
     - name: Build Base (latest)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       if: ${{ inputs.idris-version == 'latest' }}
       with:
         context: .

--- a/.github/actions/build-devcontainer-img/action.yml
+++ b/.github/actions/build-devcontainer-img/action.yml
@@ -55,7 +55,7 @@ runs:
     
     - name: Build Devcontainer (versioned)
       if: ${{ inputs.idris-lsp-version != 'latest' }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: devcontainer.Dockerfile
@@ -75,7 +75,7 @@ runs:
 
     - name: Build Devcontainer (latest)
       if: ${{ inputs.idris-lsp-version == 'latest' }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: devcontainer-latest.Dockerfile

--- a/.github/workflows/version-base-build-test.yml
+++ b/.github/workflows/version-base-build-test.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up SSH
-        uses: MrSquaare/ssh-setup-action@v3
+        uses: MrSquaare/ssh-setup-action@v4
         with:
           host: ${{ secrets.SSH_IP }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           private-key-name: oracle-arm
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           append: |
             - endpoint: ssh://${{ secrets.SSH_USER }}@${{ secrets.SSH_IP }}
@@ -48,10 +48,10 @@ jobs:
       TAG: ghcr.io/${{ github.repository }}/base:${{ inputs.idris-version }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Build Base Image
         uses: ./.github/actions/build-base-img
@@ -61,7 +61,7 @@ jobs:
           tags: ${{ env.TAG }}
 
       - name: Setup Bats and Bats libs
-        uses: bats-core/bats-action@3.0.1
+        uses: bats-core/bats-action@4.0.0
         with:
           bats-version: 1.10.0
           support-version: 0.3.0
@@ -88,10 +88,10 @@ jobs:
       TAG: idris-base-${{ inputs.idris-version }}:test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
               
       - name: Build Base Image
         uses: ./.github/actions/build-base-img

--- a/.github/workflows/version-base-deploy.yml
+++ b/.github/workflows/version-base-deploy.yml
@@ -17,23 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Set up SSH
-        uses: MrSquaare/ssh-setup-action@v3
+        uses: MrSquaare/ssh-setup-action@v4
         with:
           host: ${{ secrets.SSH_IP }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           private-key-name: oracle-arm
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           append: |
             - endpoint: ssh://${{ secrets.SSH_USER }}@${{ secrets.SSH_IP }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Docker meta
         id: create-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ github.repository }}/base
 

--- a/.github/workflows/version-devcontainer-build-test.yml
+++ b/.github/workflows/version-devcontainer-build-test.yml
@@ -28,10 +28,10 @@ jobs:
       TAG: idris-devcontainer-${{ inputs.idris-lsp-version }}:test
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Setup Buildx (no ARM)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           # since we're using a local registry
           driver-opts: network=host
@@ -56,7 +56,7 @@ jobs:
           base-tag: ${{ env.BASE_TAG }}
       
       - name: Setup Bats and Bats libs
-        uses: bats-core/bats-action@3.0.1
+        uses: bats-core/bats-action@4.0.0
         with:
           bats-version: 1.10.0
           support-version: 0.3.0

--- a/.github/workflows/version-devcontainer-deploy.yml
+++ b/.github/workflows/version-devcontainer-deploy.yml
@@ -20,23 +20,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Set up SSH
-        uses: MrSquaare/ssh-setup-action@v3
+        uses: MrSquaare/ssh-setup-action@v4
         with:
           host: ${{ secrets.SSH_IP }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           private-key-name: oracle-arm
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           append: |
             - endpoint: ssh://${{ secrets.SSH_USER }}@${{ secrets.SSH_IP }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Docker meta
         id: create-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ github.repository }}/devcontainer
 


### PR DESCRIPTION
## Summary
- Consolidates the following Renovate PRs into a single update:
  - #109 actions/checkout v6 -> v7
  - #106 MrSquaare/ssh-setup-action v3 -> v4
  - #105 docker/setup-buildx-action v3 -> v4
  - #104 docker/metadata-action v5 -> v6
  - #103 docker/login-action v3 -> v4
  - #102 docker/build-push-action v6 -> v7
  - #101 bats-core/bats-action 3.0.1 -> 4.0.0
- Closes #109, #106, #105, #104, #103, #102, #101 in favor of this PR

## Test plan
- [ ] CI workflows run green on this branch