### PR TITLE
Add Idris v0.8.0 to tracked versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Base Build & Test - ${{ matrix.idris-version }}
     strategy:
       matrix:
-        idris-version: ["v0.6.0", "v0.7.0", "latest"]
+        idris-version: ["v0.6.0", "v0.7.0", "v0.8.0", "latest"]
     uses: ./.github/workflows/version-base-build-test.yml
     with:
       idris-version: ${{ matrix.idris-version }}
@@ -34,7 +34,7 @@ jobs:
     needs: [base-build-test]
     strategy:
       matrix:
-        idris-version: ["v0.6.0", "v0.7.0", "latest"]
+        idris-version: ["v0.6.0", "v0.7.0", "v0.8.0", "latest"]
       # deploy one at a time, so the latest is always the latest deployed
       max-parallel: 1 
     uses: ./.github/workflows/version-base-deploy.yml
@@ -48,12 +48,14 @@ jobs:
     strategy:
       matrix:
         # based off of the branches in the idris-lsp repo
-        idris-lsp-version: ["idris2-0.6.0", "idris2-0.7.0", "latest"]
+        idris-lsp-version: ["idris2-0.6.0", "idris2-0.7.0", "idris2-0.8.0", "latest"]
         include:
           - idris-lsp-version: "idris2-0.6.0"
             idris-version: "v0.6.0"
           - idris-lsp-version: "idris2-0.7.0"
             idris-version: "v0.7.0"
+          - idris-lsp-version: "idris2-0.8.0"
+            idris-version: "v0.8.0"
           - idris-lsp-version: "latest"
             idris-version: "latest"
     uses: ./.github/workflows/version-devcontainer-build-test.yml
@@ -69,15 +71,17 @@ jobs:
     needs: [base-deploy, devcontainer-build-test] # needs base deployed to registry
     strategy:
       matrix:
-        idris-lsp-version: ["idris2-0.6.0", "idris2-0.7.0", "latest"]
+        idris-lsp-version: ["idris2-0.6.0", "idris2-0.7.0", "idris2-0.8.0", "latest"]
         include:
           - idris-lsp-version: "idris2-0.6.0"
             idris-version: "v0.6.0"
           - idris-lsp-version: "idris2-0.7.0"
             idris-version: "v0.7.0"
+          - idris-lsp-version: "idris2-0.8.0"
+            idris-version: "v0.8.0"
           - idris-lsp-version: "latest"
             idris-version: "latest"
-      max-parallel: 1 
+      max-parallel: 1
     uses: ./.github/workflows/version-devcontainer-deploy.yml
     with:
       idris-lsp-version: ${{ matrix.idris-lsp-version }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multi-arch Docker images for Idris 2, primarily aimed for devcontainers.
 
 Architectures: `amd64`, `arm64`
 
-Idris Versions: `v0.6.0`, `v0.7.0`, `latest` (Up to date with [Idris2/main](https://github.com/idris-lang/Idris2/tree/main) - recompiled daily)
+Idris Versions: `v0.6.0`, `v0.7.0`, `v0.8.0`, `latest` (Up to date with [Idris2/main](https://github.com/idris-lang/Idris2/tree/main) - recompiled daily)
 
 ## Table of Contents
 

--- a/scripts/build-image.py
+++ b/scripts/build-image.py
@@ -22,6 +22,7 @@ def get_lsp_version(version: str):
     '''
     version_map = {
         'latest': 'latest',
+        'v0.8.0': 'idris2-0.8.0',
         'v0.7.0': 'idris2-0.7.0',
         'v0.6.0': 'idris2-0.6.0',
     }


### PR DESCRIPTION
This adds Idris v0.8.0 as a named version. The LSP doesn't have 0.8.0 but pack auto-installs the latest version so that's not an issue. 